### PR TITLE
Push releases from the main branch

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -33,16 +33,16 @@ jobs:
 
     - name: Bump version and push tag
       id: bump
-      if: github.ref == 'refs/heads/run-tests' && github.event_name == 'push'
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: anothrNick/github-tag-action@1.26.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
-        RELEASE_BRANCHES: main,run-tests
+        RELEASE_BRANCHES: main
         INITIAL_VERSION: 0.0.0
 
     - name: Release pushes to main
-      if: github.ref == 'refs/heads/run-tests' && github.event_name == 'push'
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
         files: |


### PR DESCRIPTION
This file left pointing to the branch where the test job was added; this points it at `main` where it should be.