### PR TITLE
Incorporate lessons learned from other brokers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,143 @@
 
 .DEFAULT_GOAL := help
 
-CSB_EXEC=docker-compose exec -T broker /bin/cloud-service-broker
+DOCKER_OPTS=--rm -v $(PWD):/brokerpak -w /brokerpak
+CSB=ghcr.io/gsa/cloud-service-broker:v0.10.0gsa
+SECURITY_USER_NAME := $(or $(SECURITY_USER_NAME), user)
+SECURITY_USER_PASSWORD := $(or $(SECURITY_USER_PASSWORD), pass)
 
-clean: .env.secrets ## Bring down the broker service if it's up, clean out the database, and remove created images
-	docker-compose down -v --remove-orphans --rmi local
+SERVICE_NAME=your-service-name
+PLAN_NAME=your-plan-name
+SERVICE_ID=your-service-id
+PLAN_ID=your-plan-id
 
-# Origin of the subdirectory dependency solution: 
+CSB_EXEC=docker exec csb-service-$(SERVICE_NAME) /bin/cloud-service-broker
+CSB_SET_IDS=$(CSB_EXEC) client catalog | jq -r '.response.services[]| select(.name=="$(SERVICE_NAME)") | {serviceid: .id, planid: .plans[0].id} | to_entries | .[] | "export " + .key + "=" + (.value | @sh)'
+
+# Wait for an instance operation to complete; append with the instance id
+CSB_INSTANCE_WAIT=docker exec csb-service-$(SERVICE_NAME) ./bin/instance-wait.sh
+
+# Wait for an binding operation to complete; append with the instance id and binding id
+CSB_BINDING_WAIT=docker exec csb-service-$(SERVICE_NAME) ./bin/binding-wait.sh
+
+# Fetch the content of a binding; append with the instance id and binding id
+CSB_BINDING_FETCH=docker exec csb-service-$(SERVICE_NAME) ./bin/binding-fetch.sh
+
+
+# Use the env var INSTANCE_NAME for the name of the instance to be created, or
+# "instance-$USER" if it was not specified.
+#
+# We do this to minimize the chance of people stomping on each other when
+# provisioning resources into a shared account, and to make it easy to recognize
+# who resources belong to.
+#
+# We can also use a job ID during CI to avoid collisions from parallel
+# invocations, and make it obvious which resources correspond to which CI run.
+INSTANCE_NAME ?= instance-$(USER)
+
+# Use these parameters when provisioning an instance
+CLOUD_PROVISION_PARAMS="{}"
+
+# Use these parameters when creating a binding
+CLOUD_BIND_PARAMS="{}"
+
+PREREQUISITES = docker jq # Add others appropriate for testing your service
+K := $(foreach prereq,$(PREREQUISITES),$(if $(shell which $(prereq)),some string,$(error "Missing prerequisite commands $(prereq)")))
+
+check: ## Output variables for sanity-checking
+	@echo CSB_EXEC: $(CSB_EXEC)
+	@echo SERVICE_NAME: $(SERVICE_NAME)
+	@echo PLAN_NAME: $(PLAN_NAME)
+	@echo CLOUD_PROVISION_PARAMS: $(CLOUD_PROVISION_PARAMS)
+	@echo CLOUD_BIND_PARAMS: $(CLOUD_BIND_PARAMS)
+
+check-ids:
+	@( \
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo Service ID: $$serviceid ;\
+	echo Plan ID: $$planid ;\
+	)
+
+clean: demo-down down ## Bring down the broker service if it's up and clean out the database
+	@-docker rm -f csb-service-$(SERVICE_NAME)
+	@-rm *.brokerpak
+
+# Origin of the subdirectory dependency solution:
 # https://stackoverflow.com/questions/14289513/makefile-rule-that-depends-on-all-files-under-a-directory-including-within-subd#comment19860124_14289872
-build: manifest.yml $(shell find services) ## Build the brokerpak(s)
-	@docker run --rm --mount type=bind,src=$(PWD),dst=/source --workdir="/source" cfplatformeng/csb pak build .
+build: manifest.yml $(SERVICE_NAME).yml $(shell find terraform) ## Build the brokerpak(s)
+	docker run --user $(shell id -u):$(shell id -g) $(DOCKER_OPTS) $(CSB) pak build
 
-up: .env.secrets ## Run the broker service with the brokerpak configured. The broker listens on `0.0.0.0:8080`. curl http://127.0.0.1:8080 or visit it in your browser.
-	docker-compose up -d
-
-wait:
-	@echo "Waiting 20 seconds for the DB and broker to stabilize..."
-	@sleep 20
-	@docker-compose ps
-
-test: .env.secrets  ## Execute the brokerpak examples against the running broker
-	@echo "Running examples..."
-	$(CSB_EXEC) client run-examples
+# Healthcheck solution from https://stackoverflow.com/a/47722899
+# (Alpine inclues wget, but not curl.)
+up: ## Run the broker service with the brokerpak configured. The broker listens on `0.0.0.0:8080`. curl http://127.0.0.1:8080 or visit it in your browser.
+	docker run $(DOCKER_OPTS) \
+	-p 8080:8080 \
+	-e SECURITY_USER_NAME=$(SECURITY_USER_NAME) \
+	-e SECURITY_USER_PASSWORD=$(SECURITY_USER_PASSWORD) \
+	-e GSB_DEBUG=true \
+	-e "DB_TYPE=sqlite3" \
+	-e "DB_PATH=/tmp/csb-db" \
+	--env-file .env.secrets \
+	--name csb-service-$(SERVICE_NAME) \
+	--health-cmd="wget --header=\"X-Broker-API-Version: 2.16\" --no-verbose --tries=1 --spider http://$(SECURITY_USER_NAME):$(SECURITY_USER_PASSWORD)@localhost:8080/v2/catalog || exit 1" \
+	--health-interval=2s \
+	--health-retries=30 \
+	-d \
+	--rm \
+	$(CSB) serve
+	@./bin/docker-wait.sh csb-service-$(SERVICE_NAME)
+	@docker ps -l
 
 down: .env.secrets ## Bring the cloud-service-broker service down
-	docker-compose down
+	@-docker stop csb-service-$(SERVICE_NAME)
 
-all: clean build up wait test down ## Clean and rebuild, then bring up the server, run the examples, and bring the system down
-.PHONY: all clean build up wait test down
+# Normally we would just run `$(CSB) client run-examples` to test the brokerpak.
+# However, we may need to run tests between bind and unbind. So, we'll
+# provision+bind and unbind+deprovision manually with csb client via the "demo-up" and
+# "demo-down" targets.
+test: demo-up demo-run demo-down ## Execute the brokerpak examples against the running broker
+
+demo-up: ## Provision a service instance and output the bound credentials
+	@( \
+	set -e ;\
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo "Provisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
+	$(CSB_EXEC) client provision --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME}                     --params $(CLOUD_PROVISION_PARAMS) 2>&1 > /dev/null ;\
+	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} ;\
+	echo "Binding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding1" ;\
+	$(CSB_EXEC) client bind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding1 --params $(CLOUD_BIND_PARAMS) | jq -r .response > ${INSTANCE_NAME}.binding.json ;\
+	)
+
+
+demo-showcreds: ## Show the bound credentials
+	@$(CSB_EXEC) cloud-service-broker client credentials --bindingid binding1 --instanceid ${INSTANCE_NAME} --serviceid ${SERVICE_ID} --planid ${PLAN_ID}
+
+demo-run: SHELL:=/bin/bash
+demo-run: ## Run tests on the demo instance
+	@( \
+	set -e ;\
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo "Testing ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:bindingX" ;\
+	./test.sh ${INSTANCE_NAME}.binding.json ;\
+	)
+
+demo-down: ## Clean up data left over from tests and demos
+	@echo "Unbinding and deprovisioning the ${SERVICE_NAME} instance"
+	@( \
+	set -e ;\
+	eval "$$( $(CSB_SET_IDS) )" ;\
+	echo "Unbinding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding1" ;\
+	$(CSB_EXEC) client unbind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding1 2>&1 > /dev/null || true ;\
+	echo "Unbinding ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}:binding2" ;\
+	$(CSB_EXEC) client unbind      --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} --bindingid binding2 2>&1 > /dev/null || true ;\
+	echo "Deprovisioning ${SERVICE_NAME}:${PLAN_NAME}:${INSTANCE_NAME}" ;\
+	$(CSB_EXEC) client deprovision   --serviceid $$serviceid --planid $$planid --instanceid ${INSTANCE_NAME} 2>&1 > /dev/null || true ;\
+	$(CSB_INSTANCE_WAIT) ${INSTANCE_NAME} || true;\
+	)
+
+
+all: clean build up test down ## Clean and rebuild, then bring up the server, run the examples, and bring the system down
+.PHONY: all clean build up down test demo-up demo-down test-env-up test-env-down
 
 .env.secrets:
 	$(error Copy .env.secrets-template to .env.secrets, then edit in your own values)

--- a/README.md
+++ b/README.md
@@ -17,15 +17,29 @@ docs.
 Huge props go to @josephlewis42 of Google for publishing and publicizing the
 brokerpak concept, and to the Pivotal team running with the concept!
 
-## Prerequisites
+
+## Features/components
+
+Each brokered instance provides:
+
+- [list features of the service]
+
+## Development Prerequisites
 
 1. [Docker Desktop (for Mac or
 Windows)](https://www.docker.com/products/docker-desktop) or [Docker Engine (for
 Linux)](https://www.docker.com/products/container-runtime) is used for
 building, serving, and testing the brokerpak.
-1. `make` is used for executing docker commands in a meaningful build cycle. 
+1. [Access to the GitHub Container
+   Registry](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#authenticating-with-the-container-registry).
+   (We are working on making the necessary container image publicly accessible;
+   this step should not be necessary in future.)
 
-Run the `make` command by itself for information on the various targets that are available. 
+1. `make` is used for executing docker commands in a meaningful build cycle.
+
+
+## Developing the brokerpak
+Run the `make` command by itself for information on the various targets that are available. Notable targets are described below
 
 ```
 $ make
@@ -37,21 +51,32 @@ down       Bring the cloud-service-broker service down
 all        Clean and rebuild, then bring up the server, run the examples, and bring the system down
 help       This help
 ```
-Notable targets are described below
 
-## Building and starting the brokerpak 
-Run 
 
+### Running the brokerpak
+Run
 ```
-make up
+make build up
 ```
+The broker will start and listen on `0.0.0.0:8080`. You
+test that it's responding by running:
+```
+curl -i -H "X-Broker-API-Version: 2.16" http://user:pass@127.0.0.1:8080/v2/catalog
+```
+In response you will see a YAML description of the services and plans available
+from the brokerpak.
 
-The broker will start and listen on `0.0.0.0:8080`. You can curl
-http://127.0.0.1 or visit it in your browser.
+(Note that the `X-Broker-API-version` header is [**required** by the OSBAPI
+specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#headers).
+The broker will reject requests that don't include the header with `412
+Precondition Failed`, and browsers will show that status as `Not Authorized`.)
 
-## Testing the brokerpak (while it's running)
+You can also inspect auto-generated documentation for the brokerpak's offerings
+by visiting [`http://127.0.0.1:8080/docs`](http://127.0.0.1:8080/docs) in your browser.
 
-Run 
+### Testing the brokerpak (while it's running)
+
+Run
 ```
 make test
 ```
@@ -60,9 +85,13 @@ The [examples specified by the
 brokerpak](https://github.com/pivotal/cloud-service-broker/blob/master/docs/brokerpak-specification.md#service-yaml-flie)
 will be invoked for end-to-end testing of the brokerpak's service offerings.
 
-## Tearing down the brokerpak
+You can also manually interact with the broker using the `cloud-service-broker` CLI,
+![image](https://user-images.githubusercontent.com/85196563/163099919-656fcb63-d6d1-4190-a023-48697a34906d.png)
 
-Run 
+
+### Shutting the brokerpak down
+
+Run
 
 ```
 make down
@@ -70,15 +99,21 @@ make down
 
 The broker will be stopped.
 
-## Cleaning out the current state
+### Cleaning out the current state
 
-Run 
+Run
 ```
 make clean
 ```
-The broker image, database content, and any built brokerpak files will be removed.
+The built brokerpak files will be removed.
+
+
 
 ## Contributing
+
+Check
+out the list of [open issues](https://github.com/GSA/your-service-name/issues) for
+areas where you can contribute.
 
 See [CONTRIBUTING](CONTRIBUTING.md) for additional information.
 
@@ -89,4 +124,3 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [CONT
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
 >
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
-

--- a/bin/binding-fetch.sh
+++ b/bin/binding-fetch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Simple script to fetch the content of "instance $1 binding $2". See OSBAPI
+# spec here:
+#   https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#fetching-a-service-binding
+# 
+# This script uses the "cloud-service-broker client fetch" subcommand, and
+# requires that the necessary environment variables are set for accessing the
+# service. See configuration documentation here:
+#   https://github.com/cloudfoundry/cloud-service-broker/blob/main/docs/configuration.md#broker-service-configuration
+# 
+# =====> NOT YET! There's no client subcommand for getting the content of a
+# service binding, so we're just going to use that config in the environment
+# with curl.
+
+set -e
+
+curl -s "http://${SECURITY_USER_NAME}:${SECURITY_USER_PASSWORD}@localhost:8080/v2/service_instances/${1}/service_bindings/${2}" -X GET -H "X-Broker-API-Version: 2.16"

--- a/bin/binding-wait.sh
+++ b/bin/binding-wait.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Simple script to wait for "instance $1 binding $2" to finish the current
+# operation, and report the result. See OSBAPI spec here:
+#   https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#polling-last-operation-for-service-instances
+# 
+# This script uses the "cloud-service-broker client last" subcommand, and
+# requires that the necessary environment variables are set for accessing the
+# service. See configuration documentation here:
+#   https://github.com/cloudfoundry/cloud-service-broker/blob/main/docs/configuration.md#broker-service-configuration
+#
+# =====> NOT YET! There's no client subcommand for getting the last operation on
+# a service binding, so we're just going to use that config in the environment with curl.
+
+set -e
+
+function getLast {
+    curl -s "http://${SECURITY_USER_NAME}:${SECURITY_USER_PASSWORD}@localhost:8080/v2/service_instances/${1}/service_bindings/${2}/last_operation" -H "X-Broker-API-Version: 2.16"
+}
+
+function waitLast {
+	while true; do 
+		LAST=$(getLast "$1" "$2");
+        STATUS=$(echo "$LAST" | jq -r .status_code) 
+        STATE=$(echo "$LAST" | jq -r .response.state) 
+        if [[ $STATUS == "410" ]]; then
+            echo "gone!"
+            exit 0
+ 	    elif [[ $STATE == "failed" ]]; then
+            echo "$STATE!"
+            echo "$LAST" | jq -r .response.description
+	    exit 1
+        elif [[ $STATE == "succeeded" ]]; then
+            echo "$STATE!"
+            exit 0
+        fi
+        echo "$STATE... "
+		sleep 10
+	done
+}
+
+waitLast "$1" "$2"

--- a/bin/docker-wait.sh
+++ b/bin/docker-wait.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Simple script to wait for Docker container $1 to become healthy, according to
+# its own health check.
+# Based on https://stackoverflow.com/a/46625302/17138235
+
+set -e
+
+function getContainerHealth {
+	docker inspect --format "{{.State.Health.Status}}" $1
+}
+
+function waitContainer {
+	while STATUS=$(getContainerHealth $1); [[ $STATUS != "healthy" ]]; do 
+		if [[ $STATUS == "unhealthy" ]]; then
+			echo "Failed!"
+			exit -1
+		fi
+		printf .
+		lf=$'\n'
+		sleep 1 # Any less frequent and we might miss the "unhealthy" condition!
+	done
+	printf "$lf"
+}
+
+waitContainer $1
+
+# while true ; do
+# 	docker inspect --format "{{.State.Health.Status}}" csb-service
+# 	sleep 1
+# done

--- a/bin/instance-wait.sh
+++ b/bin/instance-wait.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Simple script to wait for instance $1 to finish the current operation, and
+# report the result. See OSBAPI spec here:
+#   https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#polling-last-operation-for-service-instances
+#
+# This script uses the "cloud-service-broker client last" subcommand, and
+# requires that the necessary environment variables are set for accessing the
+# service. See configuration documentation here:
+#   https://github.com/cloudfoundry/cloud-service-broker/blob/main/docs/configuration.md
+
+set -e
+
+function getLast {
+  /bin/cloud-service-broker client last --instanceid "$1"
+}
+
+function waitLast {
+  time=0
+  while true; do
+    LAST=$(getLast "$1");
+    STATUS=$(echo "$LAST" | jq -r .status_code)
+    STATE=$(echo "$LAST" | jq -r .response.state)
+    if [[ "$(echo "$LAST" | jq -r .response.description)" != "null" ]]; then
+      ACTION=$(echo "$LAST" | jq -r .response.description)
+    fi
+    if [[ $STATUS == "410" ]]; then
+      echo "gone!"
+      exit 0
+    elif [[ $STATE == "failed" ]]; then
+      echo "$STATE!"
+      echo "$ACTION"
+      exit 1
+    elif [[ $STATE == "succeeded" ]]; then
+      # Sometimes there is a problem even if the provision succeeded
+      echo "$STATE!"
+      echo "$ACTION"
+      exit 0
+    fi
+    echo -ne "\r$STATE | ($time seconds)..."
+    time=$(($time+10))
+    sleep 10
+  done
+}
+
+waitLast "$1"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,20 +1,18 @@
 packversion: 1
-name: my-services-pack
-version: 1.0.0
+name: datagov-brokerpak-smtp
+version: current
 metadata:
-  author: me@example.com
+  author: Bret Mogilefsky
 platforms:
-- os: linux
-  arch: "386"
 - os: linux
   arch: amd64
 terraform_binaries:
 - name: terraform
-  version: 0.12.23
-  source: https://github.com/hashicorp/terraform/archive/v0.12.23.zip  
+  version: 1.1.5
+  source: https://github.com/hashicorp/terraform/archive/v1.1.5.zip
 - name: terraform-provider-random
-  version: 2.2.1
-  source: https://releases.hashicorp.com/terraform-provider-random/2.2.1/terraform-provider-random_2.2.1_linux_amd64.zip
+  version: 3.1.2
+  source: https://releases.hashicorp.com/terraform-provider-null/3.1.0/terraform-provider-null_3.1.2_linux_amd64.zip
 service_definitions:
 - services/example-service-definition.yml
 parameters:

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Test that a provisioned instance is set up properly and meets requirements
+#   ./test.sh BINDINGINFO.json
+#
+# Returns 0 (if all tests PASS)
+#      or 1 (if any test FAILs).
+
+set -e
+retval=0
+
+if [[ -z ${1+x} ]] ; then
+    echo "Usage: ./test.sh BINDINGINFO.json"
+    exit 1
+fi
+
+SERVICE_INFO="$(jq -r .credentials < "$1")"
+
+echo "Running tests..."


### PR DESCRIPTION
- Add helper scripts to help with reading bindings and waiting on asynchronous operations
- Add much smarter, battle-tested Makefile
- Add empty test.sh script that sets up the binding info
- Update README with more detail and prompts
- Update the manifest.yml to reference recent Terraform versions