### PR TITLE
Update README to point to current trunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ provided by XXXX brokerable via the [Open Service Broker API](https://www.opense
 
 For more information about the brokerpak concept, here's a [5-minute lightning
 talk](https://www.youtube.com/watch?v=BXIvzEfHil0) from the 2019 Cloud Foundry Summit. You may also want to check out the brokerpak
-[introduction](https://github.com/pivotal/cloud-service-broker/blob/master/docs/brokerpak-intro.md)
+[introduction](https://github.com/pivotal/cloud-service-broker/blob/main/docs/brokerpak-intro.md)
 and
-[specification](https://github.com/pivotal/cloud-service-broker/blob/master/docs/brokerpak-specification.md)
+[specification](https://github.com/pivotal/cloud-service-broker/blob/main/docs/brokerpak-specification.md)
 docs.
 
 Huge props go to @josephlewis42 of Google for publishing and publicizing the
@@ -57,7 +57,7 @@ make test
 ```
 
 The [examples specified by the
-brokerpak](https://github.com/pivotal/cloud-service-broker/blob/master/docs/brokerpak-specification.md#service-yaml-flie)
+brokerpak](https://github.com/pivotal/cloud-service-broker/blob/main/docs/brokerpak-specification.md#service-yaml-flie)
 will be invoked for end-to-end testing of the brokerpak's service offerings.
 
 ## Tearing down the brokerpak


### PR DESCRIPTION
cloudfoundry/cloud-service-broker renamed their trunk to `main`